### PR TITLE
Absolute and relative path to workspace used to check code coverage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ const cachedReport: { json: { [key: string]: any } } = {
 
 function updateSign(doc: Document, sign: string, signGroup: string, signPriority: number) {
   const filepath = Uri.parse(doc.uri).fsPath;
-  const stats = cachedReport.json[filepath];
+  const workspaceDir = workspace.getWorkspaceFolder(doc.uri);
+  const relativeFilepath = workspaceDir ? path.relative(workspaceDir.uri, doc.uri) : '';
+  const stats = cachedReport.json[filepath] || cachedReport.json[relativeFilepath];
   if (stats) {
     const fileCoverage = createFileCoverage(stats);
     const uncoveredLines = fileCoverage.getUncoveredLines();


### PR DESCRIPTION
The coverage json may contain filepath relative to workspace and not
absolute filepath, check coverage data using relative path as well as
absolute path.